### PR TITLE
Fix follow-up option text consistency

### DIFF
--- a/js/history-manager.js
+++ b/js/history-manager.js
@@ -354,7 +354,7 @@ function createNoteItemHTML(note) {
     let resolutionDetailsHTML = '';
     if (resolvedSelect === 'No | Tech Booked' && dispatchDateInput && dispatchTimeSlotSelect) {
         resolutionDetailsHTML += `<div class="detail-row"><span>DISPATCH:</span><strong>${dispatchDateInput}, ${dispatchTimeSlotSelect}</strong></div>`;
-    } else if ((resolvedSelect === 'No | Follow Up Required' || resolvedSelect === 'Cx Need a Follow Up. Set SCB on FVA') && dispatchDateInput && dispatchTimeSlotSelect) {
+    } else if ((resolvedSelect === 'No | Follow Up Required' || resolvedSelect === 'No | Follow Up Required | Set SCB with FVA') && dispatchDateInput && dispatchTimeSlotSelect) {
         resolutionDetailsHTML += `<div class="detail-row"><span>FOLLOW UP:</span><strong>${dispatchDateInput}, ${dispatchTimeSlotSelect}</strong></div>`;
     } else if (resolvedSelect === 'No | BOSR Created' && cbr2Input) {
         resolutionDetailsHTML += `<div class="detail-row"><span>BOSR TICKET:</span><strong>${cbr2Input}</strong></div>`;

--- a/js/note-builder.js
+++ b/js/note-builder.js
@@ -219,7 +219,7 @@ const _buildSection4Content = (sourceData = null) => {
                 const formattedDate = `${dayAbbreviations[dateObj.getDay()]} ${monthNames[dateObj.getMonth()]} ${dateObj.getDate()}`;
                 resolutionDetails.push(`DISPATCH: ${formattedDate}, ${dispatchTime}`);
             }
-        } else if (resolvedValue === 'No | Follow Up Required' || resolvedValue === 'Cx Need a Follow Up. Set SCB on FVA') {
+        } else if (resolvedValue === 'No | Follow Up Required' || resolvedValue === 'No | Follow Up Required | Set SCB with FVA') {
             const followUpDate = _getFieldValue('dispatchDateInput', sourceData);
             const followUpTime = _getFieldValue('dispatchTimeSlotSelect', sourceData);
             if (followUpDate && followUpTime) {
@@ -270,7 +270,7 @@ function updateChecklistState() {
     setChecklistValue('checklistReboot', rebootKeywords.some(keyword => tsText.includes(keyword)) ? 'yes' : 'na');
     setChecklistValue('checklistSwap', _getFieldValue('csrOrderInput') ? 'yes' : 'na');
     const resolvedValueForCallback = _getFieldValue('resolvedSelect');
-    setChecklistValue('checklistCallback', resolvedValueForCallback === 'Cx Need a Follow Up. Set SCB on FVA' ? 'yes' : 'na');
+    setChecklistValue('checklistCallback', resolvedValueForCallback === 'No | Follow Up Required | Set SCB with FVA' ? 'yes' : 'na');
     setChecklistValue('checklistAllServices', _getFieldValue('serviceOnCsr') === 'Active' ? 'yes' : 'no');
     setChecklistValue('checklistGoSend', state.extraStepsSelected.size > 0);
 }


### PR DESCRIPTION
## Summary
- ensure follow-up option is handled consistently across modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d4e6ed1e48321827343c60a874e88