### PR TITLE
Enable spellcheck for issue textareas

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
                         <div class="grid-item grid-item-cx-issue">
                             <div class="input-group">
                                 <label for="cxIssueText">CX ISSUE</label>
-                                <textarea id="cxIssueText" name="cxIssueText" required autocomplete="off" class="shortkey-enabled" data-shortkey-tag="cx_issue"></textarea>
+                                <textarea id="cxIssueText" name="cxIssueText" required autocomplete="off" class="shortkey-enabled" data-shortkey-tag="cx_issue" spellcheck="true" lang="en"></textarea>
                             </div>
                         </div>
                         <div class="grid-item grid-item-side-info">
@@ -309,13 +309,13 @@
                                     <span>TROUBLESHOOTING PROCESS</span>
                                     <span id="troubleshootingCharCount" class="char-counter">0</span>
                                 </label>
-                                <textarea id="troubleshootingProcessText" name="troubleshootingProcessText" required autocomplete="off" class="shortkey-enabled" data-shortkey-tag="ts_steps"></textarea>
+                                <textarea id="troubleshootingProcessText" name="troubleshootingProcessText" required autocomplete="off" class="shortkey-enabled" data-shortkey-tag="ts_steps" spellcheck="true" lang="en"></textarea>
                             </div>
                         </div>
                         <div class="grid-item grid-item-additional-info">
                             <div class="input-group">
                                 <label for="additionalinfoText">ADDITIONAL INFO</label>
-                                <textarea id="additionalinfoText" name="additionalinfoText" autocomplete="off" class="shortkey-enabled"></textarea>
+                                <textarea id="additionalinfoText" name="additionalinfoText" autocomplete="off" class="shortkey-enabled" spellcheck="true" lang="en"></textarea>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- enable browser spellcheck and set language for customer issue, troubleshooting process, and additional info fields

## Testing
- `npm test` *(fails: Missing script: test)*
- `npx --yes -p playwright node -e "const {chromium}=require('playwright');..."` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6890e07417b08321a3eb21421240a0de